### PR TITLE
Add File > Export > PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.1 — 2026.09.02
 
+- File > Export > PDF writes a snapshot of the page (measure, decorations, concealed syntax) without changing the Markdown file. The page is the measure plus a margin, on the light canvas, not the live window's width or dark appearance. Block images that have not scrolled into view are decoded for the export so their bands are not empty panels.
 - Rename the app from Paper to Papel: target, bundle identifier (`org.humanitas.papel`), attribute and notification keys, the `papel` command-line launcher, the DMG, and the configuration directory. The configuration directory is now `~/.config/papel/`. The site moves to papel.sh.
 - Ship with the `apple` theme, line height 1.2, and paragraph spacing 12 as the defaults, and add the `enso` theme: white under the ink #2D2B29, and #13181C under #BFC1C3 in the dark appearance.
 - Double-click a block image to open it in the system Quick Look panel, zoomed out of its band, with ← → across the document's images and Open with Preview one click away. The pointer is the arrow over an image, and a click on one leaves the caret alone so the source line stays concealed and the band stays put (#34).

--- a/Papel/App/PDFExport.swift
+++ b/Papel/App/PDFExport.swift
@@ -1,0 +1,166 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// File > Export > PDF. The PDF is the document as a page: the configured
+/// measure, decorations, and concealed punctuation, on the light canvas,
+/// with the window's extra side slack stripped off. The Markdown file is
+/// not rewritten.
+enum PDFExport {
+    /// Side and vertical inset on the exported page. Matches
+    /// `Appearance.minimumHorizontalMargin` so the column is the measure,
+    /// not the window.
+    static let pageMargin: CGFloat = 64
+
+    /// Offers a save panel and writes the front document. Does nothing when
+    /// the key window is not a Papel document.
+    @MainActor
+    static func present() {
+        // DocumentGroup's key window is sometimes the chrome, not the
+        // document, so search every window for the editor.
+        guard let textView = NSApp.windows.lazy.compactMap({ papelTextView(in: $0) }).first else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.pdf]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.nameFieldStringValue = suggestedName(for: textView)
+        Task { @MainActor in
+            let response: NSApplication.ModalResponse
+            if let window = textView.window ?? NSApp.keyWindow {
+                response = await panel.beginSheetModal(for: window)
+            } else {
+                response = panel.runModal()
+            }
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try data(from: textView).write(to: url, options: .atomic)
+            } catch {
+                NSApp.presentError(error)
+            }
+        }
+    }
+
+    /// Suggested save-panel name: the first `#` heading, else the
+    /// document's stem, else `Untitled.pdf`.
+    @MainActor
+    static func suggestedName(for textView: PapelTextView) -> String {
+        let stem = headingTitle(in: textView.string)
+            ?? textView.documentURL?.deletingPathExtension().lastPathComponent
+        let name = (stem?.isEmpty == false) ? stem! : "Untitled"
+        return "\(name).pdf"
+    }
+
+    /// The text of the first ATX H1 (`# Title`), with characters that
+    /// cannot live in a filename replaced. `##` and deeper are skipped.
+    static func headingTitle(in source: String) -> String? {
+        for raw in source.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("#") else { continue }
+            let rest = line.drop(while: { $0 == "#" })
+            guard line.count - rest.count == 1 else { continue }
+            let title = rest.trimmingCharacters(in: .whitespaces)
+            guard !title.isEmpty else { continue }
+            return filename(from: title)
+        }
+        return nil
+    }
+
+    /// `/`, `:`, and control characters become `-`; empty after that is nil.
+    private static func filename(from title: String) -> String? {
+        let banned = CharacterSet(charactersIn: "/:\\")
+            .union(.newlines)
+            .union(.controlCharacters)
+        let cleaned = title
+            .components(separatedBy: banned)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    /// PDF bytes for `source`. Builds an offscreen copy so the live window
+    /// keeps its selection, scroll, and revealed paragraph.
+    @MainActor
+    static func data(from source: PapelTextView) -> Data {
+        let page = snapshot(of: source)
+        let light = NSAppearance(named: .aqua)!
+        var pdf = Data()
+        light.performAsCurrentDrawingAppearance {
+            pdf = page.dataWithPDF(inside: page.bounds)
+        }
+        return pdf
+    }
+
+    /// A detached text view laid out to the measure plus page margins,
+    /// forced to the light appearance, every block image decoded, and no
+    /// paragraph revealed. Drawing this view is what the PDF captures.
+    @MainActor
+    static func snapshot(of source: PapelTextView) -> PapelTextView {
+        let light = NSAppearance(named: .aqua)!
+        let width = Appearance.maximumMeasure + pageMargin * 2
+        let copy = PapelTextView()
+        copy.appearance = light
+        copy.frame = NSRect(x: 0, y: 0, width: width, height: 600)
+        copy.documentURL = source.documentURL
+        copy.string = source.string
+        light.performAsCurrentDrawingAppearance {
+            copy.syntaxStyler.apply(to: copy)
+        }
+        // Setting the string places the caret at 0, which would reveal the
+        // first paragraph. Export is the reading view: nothing revealed.
+        if let layoutManager = copy.layoutManager as? PapelLayoutManager {
+            layoutManager.setActiveRange(NSRange(location: 0, length: 0))
+        }
+        prepareImages(in: copy)
+        layoutToDocumentHeight(copy)
+        return copy
+    }
+
+    /// The PapelTextView editing the document in `window`, if any.
+    @MainActor
+    static func papelTextView(in window: NSWindow) -> PapelTextView? {
+        func search(_ view: NSView) -> PapelTextView? {
+            if let textView = view as? PapelTextView { return textView }
+            if let scroll = view as? NSScrollView,
+               let textView = scroll.documentView as? PapelTextView {
+                return textView
+            }
+            for child in view.subviews {
+                if let found = search(child) { return found }
+            }
+            return nil
+        }
+        return window.contentView.flatMap(search)
+    }
+
+    /// Drawing looks only in the image cache. Demand is viewport-scoped, so
+    /// an export would otherwise paint placeholder bands for every image
+    /// that has not scrolled into view. `entry(for:)` decodes on this
+    /// thread, which is what a save-panel action can wait for.
+    @MainActor
+    private static func prepareImages(in textView: PapelTextView) {
+        guard let storage = textView.textStorage, storage.length > 0 else { return }
+        storage.enumerateAttribute(
+            .imageSource,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, _, _ in
+            guard let url = value as? URL else { return }
+            _ = ImageStore.shared.entry(for: url)
+        }
+    }
+
+    @MainActor
+    private static func layoutToDocumentHeight(_ textView: PapelTextView) {
+        guard let layoutManager = textView.layoutManager as? PapelLayoutManager,
+              let container = textView.textContainer else { return }
+        layoutManager.ensureLayout(for: container)
+        // setFrameSize uses the window top inset (traffic lights). The
+        // PDF has no chrome, so both axes use the page margin.
+        textView.textContainerInset = NSSize(width: pageMargin, height: pageMargin)
+        layoutManager.ensureLayout(for: container)
+        let used = layoutManager.usedRect(for: container)
+        let height = used.height + pageMargin * 2
+        textView.setFrameSize(NSSize(width: textView.frame.width, height: max(height, 1)))
+        textView.textContainerInset = NSSize(width: pageMargin, height: pageMargin)
+        layoutManager.ensureLayout(for: container)
+    }
+}

--- a/Papel/App/PapelApp.swift
+++ b/Papel/App/PapelApp.swift
@@ -34,6 +34,13 @@ struct PapelApp: App {
                 Button("Add Link") { NSApp.sendAction(#selector(PapelTextView.insertLink(_:)), to: nil, from: nil) }
                     .keyboardShortcut("k", modifiers: .command)
             }
+            CommandGroup(after: .saveItem) {
+                Menu("Export") {
+                    Button("PDF...") {
+                        PDFExport.present()
+                    }
+                }
+            }
             CommandGroup(replacing: .toolbar) {
                 Button("Toggle Full Screen") {
                     NSApp.keyWindow?.toggleFullScreen(nil)

--- a/PapelTests/PDFExportTests.swift
+++ b/PapelTests/PDFExportTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Testing
+@testable import Papel
+
+@MainActor
+struct PDFExportTests {
+    private func styledView(_ text: String, documentURL: URL? = nil, width: CGFloat = 800) -> PapelTextView {
+        let textView = PapelTextView()
+        textView.frame = NSRect(x: 0, y: 0, width: width, height: 600)
+        textView.documentURL = documentURL
+        textView.string = text
+        textView.syntaxStyler.apply(to: textView)
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        return textView
+    }
+
+    @Test
+    func pdfDataBeginsWithThePDFHeader() {
+        let textView = styledView("# Hello\n\n> A quiet page.\n")
+        let data = PDFExport.data(from: textView)
+        #expect(data.starts(with: Data("%PDF".utf8)))
+        #expect(data.count > 200)
+    }
+
+    @Test
+    func snapshotConcealsEveryParagraph() throws {
+        let textView = styledView("# Title\n\n> quoted\n")
+        let page = PDFExport.snapshot(of: textView)
+        let layoutManager = try #require(page.layoutManager as? PapelLayoutManager)
+        layoutManager.ensureLayout(for: page.textContainer!)
+        #expect(layoutManager.activeRange == NSRange(location: 0, length: 0))
+        #expect(layoutManager.isConcealed(characterAt: 0), "the heading marker hides")
+        let quote = (page.string as NSString).range(of: ">")
+        #expect(quote.location != NSNotFound)
+        #expect(layoutManager.isConcealed(characterAt: quote.location), "the quote marker hides")
+    }
+
+    @Test
+    func exportLeavesTheSourceViewSelectionAlone() {
+        let textView = styledView("# Title\n\nBody.\n")
+        let selection = NSRange(location: 0, length: 0)
+        textView.setSelectedRange(selection)
+        let layoutManager = textView.layoutManager as! PapelLayoutManager
+        let revealed = layoutManager.activeRange
+        _ = PDFExport.data(from: textView)
+        #expect(textView.selectedRange() == selection)
+        #expect(layoutManager.activeRange == revealed)
+    }
+
+    @Test
+    func suggestedNameUsesTheH1() {
+        let textView = styledView("# Hello There\n\nBody.\n", documentURL: URL(fileURLWithPath: "/tmp/notes.md"))
+        #expect(PDFExport.suggestedName(for: textView) == "Hello There.pdf")
+    }
+
+    @Test
+    func suggestedNameSkipsDeeperHeadings() {
+        #expect(PDFExport.headingTitle(in: "## Not this\n# This one\n") == "This one")
+        #expect(PDFExport.headingTitle(in: "plain\n# Hello There\n") == "Hello There")
+        #expect(PDFExport.headingTitle(in: "# Path/Name: Draft\n") == "Path-Name- Draft")
+    }
+
+    @Test
+    func suggestedNameUsesTheDocumentStem() {
+        let textView = styledView("hi", documentURL: URL(fileURLWithPath: "/tmp/notes.md"))
+        #expect(PDFExport.suggestedName(for: textView) == "notes.pdf")
+    }
+
+    @Test
+    func suggestedNameForAnUntitledDocument() {
+        let textView = styledView("hi")
+        #expect(PDFExport.suggestedName(for: textView) == "Untitled.pdf")
+    }
+
+    @Test
+    func snapshotFitsTheMeasureAndUsesTheLightAppearance() {
+        let textView = styledView("# Hello\n\nA line.\n", width: 1400)
+        let page = PDFExport.snapshot(of: textView)
+        let expectedWidth = Appearance.maximumMeasure + PDFExport.pageMargin * 2
+        #expect(abs(page.bounds.width - expectedWidth) < 0.5)
+        #expect(page.textContainerInset.width == PDFExport.pageMargin)
+        #expect(page.textContainerInset.height == PDFExport.pageMargin)
+        #expect(page.appearance?.name == .aqua)
+        #expect(PDFExport.pageMargin == Appearance.minimumHorizontalMargin)
+    }
+
+    @Test
+    func exportDecodesDocumentImages() throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("papel-pdf-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let image = folder.appendingPathComponent("shot.png")
+        let rep = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 64, pixelsHigh: 32, bitsPerSample: 8,
+            samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB,
+            bytesPerRow: 0, bitsPerPixel: 0
+        ))
+        try #require(rep.representation(using: .png, properties: [:])).write(to: image)
+
+        let documentURL = folder.appendingPathComponent("doc.md")
+        let textView = styledView("![shot](shot.png)\n", documentURL: documentURL)
+        #expect(!ImageStore.shared.isCached(image.standardizedFileURL))
+        _ = PDFExport.data(from: textView)
+        #expect(ImageStore.shared.isCached(image.standardizedFileURL))
+    }
+}


### PR DESCRIPTION
@dremnik for review. I don't have permission to add you as a reviewer on this repo.

## Summary
- File > Export > PDF writes the page as it draws: measure, decorations, and concealed syntax. The Markdown file is left alone.
- The page is the measure plus a 64pt margin, on the light canvas, not the live window's width or dark appearance.
- The save panel name is the first `#` heading, then the document stem, then `Untitled.pdf`.
- Block images that have not scrolled into view are decoded for the export so those bands are not empty panels.

Rebased onto current master after the Paper → Papel rename.

## Before
File menu on 0.3.0, no Export.

![File menu without Export](https://litter.catbox.moe/wk7ke6.png)

## After
File > Export > PDF, then a light page sized to the measure.

![File menu with Export PDF](https://litter.catbox.moe/l9wg4u.png)

![Exported PDF page](https://litter.catbox.moe/zvewrj.png)

## Test plan
- [ ] File > Export > PDF on the README. Suggested name is the first H1 (`Papel.pdf` on current master).
- [ ] Export while the window is in the dark appearance. The PDF is still light.
- [ ] A document with no `#` heading uses the file stem; an untitled buffer uses `Untitled.pdf`.
- [ ] An image below the fold is in the PDF, not an empty band.
- [ ] The open document stays unmarked and the Markdown on disk is unchanged.